### PR TITLE
Removed AWSTemplateFormatVersion from `required`

### DIFF
--- a/src/main/resources/Schema.template
+++ b/src/main/resources/Schema.template
@@ -84,5 +84,5 @@
     }
   },
   "description" : "{{description}}",
-  "required" : [ "AWSTemplateFormatVersion", "Resources" ]
+  "required" : [ "Resources" ]
 }


### PR DESCRIPTION
Only `Resources` is required for a CloudFormation template.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
