### PR TITLE
Added additional validation to Resources block

### DIFF
--- a/src/main/java/aws/cfn/codegen/json/Codegen.java
+++ b/src/main/java/aws/cfn/codegen/json/Codegen.java
@@ -129,8 +129,12 @@ public final class Codegen {
                 ObjectNode definitions = e.getValue();
                 ObjectNode resourcesDefnSide = definitions.putObject("resources");
                 resourcesDefnSide.put("type", "object");
-                ObjectNode addProps = resourcesDefnSide.putObject("additionalProperties");
-                ArrayNode oneOf = addProps.putArray("oneOf");
+                resourcesDefnSide.put("additionalProperties", false);
+                resourcesDefnSide.put("maxProperties", 200);
+                resourcesDefnSide.put("minProperties", 1);
+                ObjectNode patternProps = resourcesDefnSide.putObject("patternProperties");
+                ObjectNode resourceProps = patternProps.putObject("^[a-zA-Z0-9]{1,255}$");
+                ArrayNode oneOf = resourceProps.putArray("oneOf");
                 for (String eachDefn: definitionNames) {
                     if (definitions.has(eachDefn)) {
                         ObjectNode ref = oneOf.addObject();


### PR DESCRIPTION
Added additional validation to Resources block

- must be at least 1 Resource
- must be no more than 200 Resources
- Resource names can only be alpha-numeric, and from 1-255 chars

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
