### PR TITLE
Added a missing prefix which isn't under `AWS::`

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -84,4 +84,5 @@ groups:
   all:
     includes:
       - AWS.*
+      - Alexa.*
 


### PR DESCRIPTION
__Now__ it's "all".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
