### PR TITLE
Added PrimitiveType mapping for `Map`

### DIFF
--- a/src/main/java/aws/cfn/codegen/json/Codegen.java
+++ b/src/main/java/aws/cfn/codegen/json/Codegen.java
@@ -275,7 +275,7 @@ public final class Codegen {
             put("Json", () -> "object");
             put("Boolean", () -> "boolean");
             put("Timestamp", () -> "string");
-
+            put("Map", () -> "object");
         }};
 
     private void addDependsOn(ObjectNode addTo) {
@@ -384,6 +384,7 @@ public final class Codegen {
 
     private void addPrimitiveType(ObjectNode each, String propType) {
         if (config.getSettings().getDraft() == SchemaDraft.draft07) {
+            Supplier<String> supplier = PrimitiveMappings.get(propType);
             String type = PrimitiveMappings.get(propType).get();
 
             if (config.getSettings().getIncludeIntrinsics()) {


### PR DESCRIPTION
*Description of changes:* Added PrimitiveType mapping for `Map`

This is probably a modelling defect in the AWS::ServiceDiscovery::Instance resource type but it's there now.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
