### PR TITLE
Fixing Lombok/Surefire Maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,26 +35,26 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.16.20</version>
+      <version>1.16.22</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>[2.9.9,)</version>
+      <version>2.9.9</version>
     </dependency>
 	 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>[2.9.9,)</version>
+      <version>2.9.9</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml -->
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>[2.9.9,)</version>
+      <version>2.9.9</version>
     </dependency>
 
     <dependency>
@@ -98,7 +98,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20.1</version>
+          <version>2.22.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
https://github.com/rzwitserloot/lombok/issues/1651, https://github.com/rzwitserloot/lombok/issues/1572, https://github.com/junit-team/junit4/issues/1513

I'm not sure what changed between https://github.com/awslabs/aws-cfn-lint-visual-studio-code/pull/78 and https://github.com/awslabs/aws-cfn-lint-visual-studio-code/pull/79 that exposed this, so I've pinned the Jackson dependencies in an attempt to make the build more deterministic as well

---

```shell
~/Documents/Github/aws-cloudformation-template-schema $ mvn clean package
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------< aws.cfn.codegen:aws-cloudformation-template-schema >---------
[INFO] Building aws-cloudformation-template-schema 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:3.0.0:clean (default-clean) @ aws-cloudformation-template-schema ---
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ aws-cloudformation-template-schema ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 3 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.7.0:compile (default-compile) @ aws-cloudformation-template-schema ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 12 source files to /Users/pmyron/Documents/Github/aws-cloudformation-template-schema/target/classes
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by lombok.javac.apt.LombokProcessor to field com.sun.tools.javac.processing.JavacProcessingEnvironment.discoveredProcs
WARNING: Please consider reporting this to the maintainers of lombok.javac.apt.LombokProcessor
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.988 s
[INFO] Finished at: 2020-02-20T19:04:36-08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.7.0:compile (default-compile) on project aws-cloudformation-template-schema: Fatal error compiling: java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTags -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException

~/Documents/Github/aws-cloudformation-template-schema $ mvn clean package
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------< aws.cfn.codegen:aws-cloudformation-template-schema >---------
[INFO] Building aws-cloudformation-template-schema 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from central: https://repo.maven.apache.org/maven2/org/projectlombok/lombok/1.16.22/lombok-1.16.22.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/projectlombok/lombok/1.16.22/lombok-1.16.22.pom (1.6 kB at 7.5 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/projectlombok/lombok/1.16.22/lombok-1.16.22.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/projectlombok/lombok/1.16.22/lombok-1.16.22.jar (1.6 MB at 660 kB/s)
[INFO] 
[INFO] --- maven-clean-plugin:3.0.0:clean (default-clean) @ aws-cloudformation-template-schema ---
[INFO] Deleting /Users/pmyron/Documents/Github/aws-cloudformation-template-schema/target
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ aws-cloudformation-template-schema ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 3 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.7.0:compile (default-compile) @ aws-cloudformation-template-schema ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 12 source files to /Users/pmyron/Documents/Github/aws-cloudformation-template-schema/target/classes
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ aws-cloudformation-template-schema ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /Users/pmyron/Documents/Github/aws-cloudformation-template-schema/src/test/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.7.0:testCompile (default-testCompile) @ aws-cloudformation-template-schema ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 2 source files to /Users/pmyron/Documents/Github/aws-cloudformation-template-schema/target/test-classes
[INFO] 
[INFO] --- maven-surefire-plugin:2.20.1:test (default-test) @ aws-cloudformation-template-schema ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.396 s
[INFO] Finished at: 2020-02-20T19:11:51-08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.20.1:test (default-test) on project aws-cloudformation-template-schema: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.20.1:test failed.: NullPointerException -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
