### PR TITLE
testing end-to-end Template Schema generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ install:
 script:
   - pre-commit run --all-files --verbose
   - mvn clean verify
-  - mvn clean package
   - |
     echo 'settings:
       regions: [test]

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
   - mvn clean verify
   - mvn clean package
   - |
-  echo 'settings:
-  regions: [us-east-1]
-  output: cfn-schemas' > cfg.yml
+    echo 'settings:
+    regions: [us-east-1]
+    output: cfn-schemas' > cfg.yml
   - java -jar target/aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar --config-file cfg.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ script:
   - mvn clean package
   - |
     echo 'settings:
-      regions: [us-east-1]
+      regions: [test]
       output: cfn-schemas' > cfg.yml
   - java -jar target/aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar --config-file cfg.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,9 @@ install:
 script:
   - pre-commit run --all-files --verbose
   - mvn clean verify
+  - mvn clean package
+  - |
+  echo 'settings:
+  regions: [us-east-1]
+  output: cfn-schemas' > cfg.yml
+  - java -jar target/aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar --config-file cfg.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ script:
   - mvn clean package
   - |
     echo 'settings:
-    regions: [us-east-1]
-    output: cfn-schemas' > cfg.yml
+      regions: [us-east-1]
+      output: cfn-schemas' > cfg.yml
   - java -jar target/aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar --config-file cfg.yml

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -32,6 +32,7 @@ settings:
 
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html
 specifications:
+  test: https://cfn-resource-specifications-us-east-1-prod.s3.us-east-1.amazonaws.com/14.1.0/gzip/CloudFormationResourceSpecification.json
   af-south-1: https://cfn-resource-specifications-af-south-1-prod.s3.af-south-1.amazonaws.com/latest/gzip/CloudFormationResourceSpecification.json
   ap-east-1: https://cfn-resource-specifications-ap-east-1-prod.s3.ap-east-1.amazonaws.com/latest/gzip/CloudFormationResourceSpecification.json
   ap-northeast-1: https://d33vqc0rt9ld30.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json


### PR DESCRIPTION
[VSCode Template Schema PRs](https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pulls?q=is:pr+%22Template+Schema%22)

adding testing beyond https://github.com/aws-cloudformation/aws-cloudformation-template-schema/pull/42 to test [Template Schema generation](https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pull/76)

---

**Using the latest [Resource Specification](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) results in:**

[`Json referenced but not defined in AWS::IoT::ProvisioningTemplate`](https://travis-ci.com/github/aws-cloudformation/aws-cloudformation-template-schema/builds/172259210#L2511)

https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-iot/pull/1#discussion_r437761778

don't think we want to include [Resource Specification](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) JSON patching in this repository as well..

could switch regions to avoid the [`AWS::IoT::ProvisioningTemplate`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-provisioningtemplate.html) error but the Resource Specification for [`AWS::SSM::Association`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-association.html) is also malformed and [available in every region](https://raw.githubusercontent.com/ScriptAutomate/aws-cfn-resource-specs/master/supported-regions-per-resource.json)

---

**so trying the last [Resource Specification](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) version without property types `referenced but not defined`:**
https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pull/100

---

Probably will start failing if this dependabot commit is merged into this branch:
https://github.com/aws-cloudformation/aws-cloudformation-template-schema/pull/44#issuecomment-652625502

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.