### PR TITLE
linking pre-configured CloudFormation Linter Visual Studio Code extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Here is a VSCode setup integration example
 
 #### VS Code
 
-For [VS Code](https://code.visualstudio.com/) please follow the [setup/guidelines](docs/vscode/instructions.md)
+For [VS Code](https://code.visualstudio.com/) please follow the [setup/guidelines](docs/vscode/instructions.md) or install the pre-configured [CloudFormation Linter VS Code extension](https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code)
 
 #### PyCharm
 


### PR DESCRIPTION
https://github.com/aws-cloudformation/aws-cloudformation-template-schema/issues/38

[the hosted Template Schema is outdated (2018)](https://github.com/aws-cloudformation/aws-cloudformation-template-schema/issues/32)
[and most recent CloudFormation Resource Specifications have property types `referenced but not defined` that cause issues generating newer Template Schemas](https://github.com/aws-cloudformation/aws-cloudformation-template-schema/pull/43)

It'll be easier for most customers to install [the extension](https://marketplace.visualstudio.com/items?itemName=kddejong.vscode-cfn-lint) that is [maintaining newer Template Schemas for them](https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pulls?q=is:pr+%22Template+Schema%22) than to use the [outdated hosted Template Schema](https://s3.amazonaws.com/cfn-resource-specifications-us-east-1-prod/schemas/2.15.0/all-spec.json) or maintain newer version themselves since undefined property types need to be handled

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
