### PR TITLE
DeletionPolicy and UpdateReplacePolicy

### DIFF
--- a/src/main/java/aws/cfn/codegen/json/Codegen.java
+++ b/src/main/java/aws/cfn/codegen/json/Codegen.java
@@ -326,6 +326,15 @@ public final class Codegen {
             enumType.put("type", "string");
             ArrayNode array = enumType.putArray("enum");
             array.add(name);
+
+            for (String policyName: new String[]{"DeletionPolicy", "UpdateReplacePolicy"}) {
+                ObjectNode policy = resProps.putObject(policyName);
+                policy.put("description", "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-" + policyName.toLowerCase() + ".html");
+                policy.put("type", "string");
+                ArrayNode policyArray = policy.putArray("enum");
+                policyArray.add("Delete").add("Retain").add("Snapshot");
+            }
+
             innerProps = resProps.putObject("Properties");
             innerProps.put("type", "object");
             properties = innerProps.putObject("properties");


### PR DESCRIPTION
https://github.com/aws-cloudformation/aws-cloudformation-template-schema/issues/31 @kaihendry
[`DeletionPolicy`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html)
[`UpdateReplacePolicy`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html)

`Snapshot` policies are only supported for a few resource types
but not limiting here in hopes that `Snapshot` policy coverage expands:
https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/224

<img width="930" alt="Screen Shot 2020-09-20 at 12 25 42 AM" src="https://user-images.githubusercontent.com/7014355/93706093-d794fe80-fad7-11ea-9793-d949bcb2d8fe.png">

---

JSON schema snippet generated for each resource type:

```json
      "DeletionPolicy" : {
        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
        "type" : "string",
        "enum" : [ "Delete", "Retain", "Snapshot" ]
      },
      "UpdateReplacePolicy" : {
        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
        "type" : "string",
        "enum" : [ "Delete", "Retain", "Snapshot" ]
      },
```