### PR TITLE
removing CloudFormation template limit verification due to increased limits

### DIFF
--- a/src/main/java/aws/cfn/codegen/json/Codegen.java
+++ b/src/main/java/aws/cfn/codegen/json/Codegen.java
@@ -149,7 +149,6 @@ public final class Codegen {
                 ObjectNode resourcesDefnSide = definitions.putObject("resources");
                 resourcesDefnSide.put("type", "object");
                 resourcesDefnSide.put("additionalProperties", false);
-                resourcesDefnSide.put("maxProperties", 200);
                 resourcesDefnSide.put("minProperties", 1);
                 ObjectNode patternProps = resourcesDefnSide.putObject("patternProperties");
                 ObjectNode resourceProps = patternProps.putObject("^[a-zA-Z0-9]{1,255}$");

--- a/src/main/resources/Schema.template
+++ b/src/main/resources/Schema.template
@@ -54,7 +54,6 @@
         }
       },
       "minProperties": 1,
-      "maxProperties": 64,
       "additionalProperties": false
     },
     "Mapping": {
@@ -65,7 +64,6 @@
         }
       },
       "minProperties": 1,
-      "maxProperties": 64,
       "additionalProperties": false
     },
     "CommonParams": {
@@ -356,7 +354,6 @@
           "$ref": "#/definitions/Mapping"
         }
       },
-      "maxProperties": 100,
       "additionalProperties": false
     },
     "Conditions": {


### PR DESCRIPTION
https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/360
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html
https://aws.amazon.com/about-aws/whats-new/2020/10/aws-cloudformation-now-supports-increased-limits-on-five-service-quotas/

```bash
git grep 'maxProperties' .
```