### PR TITLE
CreationPolicy and UpdatePolicy

### DIFF
--- a/src/main/java/aws/cfn/codegen/json/Codegen.java
+++ b/src/main/java/aws/cfn/codegen/json/Codegen.java
@@ -334,7 +334,7 @@ public final class Codegen {
                 policyArray.add("Delete").add("Retain").add("Snapshot");
             }
 
-            for (String attributeName: new String[]{"Metadata"}) {
+            for (String attributeName: new String[]{"Metadata", "CreationPolicy", "UpdatePolicy"}) {
                 ObjectNode attribute = resProps.putObject(attributeName);
                 attribute.put("description", "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-" + attributeName.toLowerCase() + ".html");
                 attribute.put("type", "object");


### PR DESCRIPTION
https://github.com/aws-cloudformation/aws-cloudformation-template-schema/issues/31
[`CreationPolicy`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-creationpolicy.html)
[`UpdatePolicy`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html)

---

JSON schema snippet generated for each resource type:

```json
      "CreationPolicy" : {
        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-creationpolicy.html",
        "type" : "object"
      },
      "UpdatePolicy" : {
        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html",
        "type" : "object"
      },
```

![Screen Shot 2020-10-23 at 1 41 47 PM](https://user-images.githubusercontent.com/7014355/97052265-85f7ed80-1535-11eb-819c-5d0534ad3415.png)

![Screen Shot 2020-10-23 at 1 43 40 PM](https://user-images.githubusercontent.com/7014355/97052396-c8212f00-1535-11eb-9c43-bbb424128921.png)

![Screen Shot 2020-10-23 at 1 43 22 PM](https://user-images.githubusercontent.com/7014355/97052400-cb1c1f80-1535-11eb-8d6d-95d770923688.png)

---

only specific configurations supported for a few resource types

[`cfn-lint` already contains `UpdatePolicy` validation](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/src/cfnlint/rules/resources/updatepolicy/Configuration.py), so not going to replicate that here